### PR TITLE
chore: dependabot grouping + repo hygiene workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions-all:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+on: pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch/minor
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL" || gh pr merge --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: Close stale PRs and branches
+on:
+  schedule:
+    - cron: "0 6 * * 1-5"
+  workflow_dispatch:
+permissions:
+  pull-requests: write
+  issues: write
+  contents: write
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 14
+          days-before-pr-close: 3
+          stale-pr-message: "Idle >14 days — marking stale; closes in 3 days per repo policy (COMMIT-PR-RULES)."
+          close-pr-message: "Closed as stale (idle >14 days). Reopen if still needed."
+          delete-branch: true
+          exempt-pr-labels: "keep,security,pinned,work-in-progress"
+          days-before-issue-stale: -1


### PR DESCRIPTION
Automated repo hygiene per COMMIT-PR-RULES.md:\n- Grouped weekly Dependabot (one minor/patch PR per ecosystem, auto-merge on green)\n- actions/stale (idle>14d)\n- Dependabot auto-merge workflow\n

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Dependabot grouping, auto-merge, and stale PR workflows
> - Adds [dependabot.yml](.github/dependabot.yml) configuring weekly grouped Dependabot PRs for npm (minor/patch only, max 5 open) and GitHub Actions dependencies.
> - Adds [dependabot-automerge.yml](.github/workflows/dependabot-automerge.yml) to auto-merge (squash) Dependabot PRs for semver patch and minor updates, deleting branches on merge.
> - Adds [stale.yml](.github/workflows/stale.yml) to mark PRs inactive for 14 days as stale and close them after 3 more days, deleting their branches. Issues are unaffected.
> - Behavioral Change: PRs from Dependabot for patch/minor updates will merge automatically without manual review.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fc63733. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->